### PR TITLE
checks for PROJECT_ID env

### DIFF
--- a/reqKick.app.js
+++ b/reqKick.app.js
@@ -29,7 +29,7 @@ function checkENVs() {
   logger.info(who, 'Inside');
 
   var expectedENVs = ['STATUS_DIR', 'REQEXEC_BIN_PATH',
-    'NODE_ID', 'SHIPPABLE_NODE_ARCHITECTURE',
+    'NODE_ID', 'PROJECT_ID', 'SHIPPABLE_NODE_ARCHITECTURE',
     'SHIPPABLE_NODE_OPERATING_SYSTEM', 'SHIPPABLE_API_URL'];
 
   var errors = [];


### PR DESCRIPTION
https://github.com/Shippable/kermit-reqKick/issues/28

We added PROJECT_ID env in the template of few operating systems and architectures as part of https://github.com/Shippable/kermit-reqKick/pull/29  and adding a check for it in this PR 